### PR TITLE
feat(fmt): run fmt on project

### DIFF
--- a/bitbucket/data_repository.go
+++ b/bitbucket/data_repository.go
@@ -2,7 +2,7 @@ package bitbucket
 
 import (
 	"fmt"
-	
+
 	"github.com/hashicorp/terraform/helper/schema"
 )
 

--- a/bitbucket/provider.go
+++ b/bitbucket/provider.go
@@ -46,7 +46,7 @@ func Provider() terraform.ResourceProvider {
 			"bitbucketserver_repository_permissions_users":  dataSourceRepositoryPermissionsUsers(),
 			"bitbucketserver_user":                          dataSourceUser(),
 			"bitbucketserver_project":                       dataSourceProject(),
-			"bitbucketserver_repository":					 dataSourceRepository(),
+			"bitbucketserver_repository":                    dataSourceRepository(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"bitbucketserver_banner":                       resourceBanner(),


### PR DESCRIPTION
### Description
After a fresh pull I ran the `make test` command. It failed with
```
> make test
==> Checking that code complies with gofmt requirements...
gofmt needs running on the following files:
./bitbucket/provider.go
./bitbucket/data_repository.go
You can use the command: `make fmt` to reformat code.
make: *** [fmtcheck] Error 1
```
These changes are the direct result of running `make fmt`. Following this the tests pass as expected.
```
> make test
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
go: -i flag is deprecated
go: downloading github.com/golang/mock v1.3.1
go: downloading github.com/go-test/deep v1.0.1
echo $(go list ./... |grep -v 'vendor') | \
                xargs -t -n4 go test -race -coverprofile=coverage.txt -covermode=atomic -timeout=30s -parallel=4
go test -race -coverprofile=coverage.txt -covermode=atomic -timeout=30s -parallel=4 github.com/ubiquitousbear/terraform-provider-bitbucketserver github.com/ubiquitousbear/terraform-provider-bitbucketserver/bitbucket github.com/ubiquitousbear/terraform-provider-bitbucketserver/bitbucket/marketplace
?       github.com/ubiquitousbear/terraform-provider-bitbucketserver    [no test files]
ok      github.com/ubiquitousbear/terraform-provider-bitbucketserver/bitbucket  0.405s  coverage: 3.1% of statements
?       github.com/ubiquitousbear/terraform-provider-bitbucketserver/bitbucket/marketplace      [no test files]
```